### PR TITLE
Netmiko4

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The DATA can be either a CSV file or an Excel file. In both cases you can define
 
 The first column `_1` or the `ip` column (or eventually changed by `-gc`) allows `taskAutom` to group routers by that column when processing data. This is particularly useful if you have the same router along several rows in the DATA file.
 
-If you want `taskAutom` not to group routers by the `[ip|_1]` column, you should use the `-so/--strictOrder yes` CLI parameter: this will process the routers' data in the order that it is inside the DATA file.
+If you want `taskAutom` not to group routers by the `[ip|_1]` column, you should use the `-so/--strictOrder yes` CLI parameter: this will process the routers' data in the order of the DATA file as is.
 
 The next columns in the DATA file, are the variables that will be used in the configuration template.
 
@@ -94,14 +94,14 @@ def construir_cliLine(m, datos, lenData, mop=None):
 
 	cfg        = ""
 
-	if mop and m == 0:
-		cfg = "\nHeading_2:Router: " + router + ", " + ipSystem + "\n"
+    if mop and m == 0:
+        cfg = "\nHeading_2:Router: " + router + ", " + ipSystem + "\n"
 
-	cfg = cfg + "/configure router interface " + intName + " port " + port + "\n"
-	cfg = cfg + "/configure router interface " + intName + " address " + address + "\n"
+    cfg = cfg + "/configure router interface " + intName + " port " + port + "\n"
+    cfg = cfg + "/configure router interface " + intName + " address " + address + "\n"
 
     if m == lenData-1:
-        cfg = cfg + "/configure router interface " + intName + " no shutdown\n"
+        cfg = cfg + "/configure router interface " + intName + " no shutdown\n" 
 
 	return cfg
 ```

--- a/README.md
+++ b/README.md
@@ -117,12 +117,12 @@ def construir_cliLine(m, datos, lenData, mop=None):
 
 By default, `taskAutom` connects to each and every router that exists inside the DATA data file. Optionally, an inventory file can be provided, with per router connection parameters. If so, the default connection values are overridden by those inside the inventory file.
 
-ip|username|password|useSSHTunnel|telnetTimeout|delayFactor|deviceType|jumpHost|maxLoops
---|--------|--------|------------|-------------|-----------|----------|--------|---------
-10.0.0.1|user1|pass1|yes||0.5|nokia_sros|server1|1000
-10.0.0.2|user2|pass2|no|90||nokia_sros_telnet|
+ip|username|password|useSSHTunnel|readTimeOut|deviceType|jumpHost|
+--|--------|--------|------------|----------|--------|---------
+10.0.0.1|user1|pass1|yes|15|nokia_sros|server1|1000
+10.0.0.2|user2|pass2|no|90|nokia_sros_telnet|
 
-If fieds in the CSV are left empty, those are replaced by default values.
+If fieds in the inventory CSV file are left empty, default values are used.
 
 ### MOP
 
@@ -190,10 +190,8 @@ optional arguments:
                         Generate MOP. Default=no
   -crt CRONTIME [CRONTIME ...], --cronTime CRONTIME [CRONTIME ...]
                         Data for CRON: name(ie: test), month(ie april), weekday(ie monday), day-of-month(ie 28), hour(ie 17), minute(ie 45).
-  -df DELAYFACTOR, --delayFactor DELAYFACTOR
-                        SSH delay factor. Increase if the network is lossy and/on noissy. Improves interaction with the network. Default=1
-  -sml MAXLOOPS, --maxLoops MAXLOOPS
-                        SSH MaxLoops. Increase if long outputs are to be expected per each command (mainly for show commands). Default=5000
+  -rto READTIMEOUT, --readTimeOut READTIMEOUT
+                        Read Timeout. Time in seconds which to wait for data from router. Default=10
   -tun {no,yes}, --sshTunnel {no,yes}
                         Use SSH Tunnel to routers. Default=yes
   -dt {nokia_sros,nokia_sros_telnet}, --deviceType {nokia_sros,nokia_sros_telnet}
@@ -206,4 +204,5 @@ optional arguments:
                         Enable cmdVerify when interacting with router. Disable only if connection problems. Default=yes
   -sd {no,yes}, --sshDebug {no,yes}
                         Enables debuging of SSH interaction with the network. Stored on debug.log. Default=no
+
 ```

--- a/README.md
+++ b/README.md
@@ -63,9 +63,10 @@ If you want `taskAutom` not to group routers by the `[ip|_1]` column, you should
 
 The next columns in the DATA file, are the variables that will be used in the configuration template.
 
-**Example:** this is a CSV for two different routers, including the data to modify their interfaces. No header is being used.
+**Example:** this is a CSV for two different routers, including the data to modify their interfaces. A header is being used in this case.
 
 ```csv
+ip,name,port,interName,ipAddress
 10.0.0.1,router1,1/1/1,inter1,192.168.0.1/30
 10.0.0.2,router2,1/3/5,inter7,192.168.2.1/30
 ```
@@ -85,11 +86,11 @@ The plugin is a Python code which is fed with each row of the DATA file at a tim
 ```python
 def construir_cliLine(m, datos, lenData, mop=None):
 
-	ipSystem   = datos._1
-	router     = datos._2
-	port       = datos._3
-	intName    = datos._4
-	address    = datos._5
+	ipSystem   = datos.ip
+	router     = datos.name
+	port       = datos.port
+	intName    = datos.interName
+	address    = datos.ipAddress
 
 	cfg        = ""
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ When writing a plugin, is important to help `taskAutom` understand which string 
 If `taskAutom` is invoked with option `-j/--jobType 0`, a text file with the rendered output, will be genereated.
 
 ```bash
-$ taskAutom -d listExample.csv -py confExample.py -j 0
+$ taskAutom -d example/example.csv -py example/example.py -l test -j 0
 
 Router: router1, 10.0.0.1
 /configure router interface inter1 port 1/1/1

--- a/changelog.md
+++ b/changelog.md
@@ -4,12 +4,15 @@
 
 - Upgrade of `netmiko` library to version 4.1.0
     - `delayFactor` and `maxLoops` are no longer used;
-    - New parameter `readTimeOut` is used insted. In seconds, sets the amount of time `taskAutom` waits for output from router.
+    - New parameter `readTimeOut` is used insted. In seconds, sets the amount of time `taskAutom` waits for output from router. Default to 10 seconds.
     - This change also affects the building of the inventory file, if used.
 - Upgrade of `paramiko` library to version 2.11.0
 - Better detection of ssh-tunnels under the function `fncSshServer()`.
 - Final report shows times in minutes if greater than 120s.
-- In function `fncWriteToConnection()` the `expect_string` was disabled from the `send_command()` method.
+- In the definition of the dictionary `DICT_VENDOR`
+    - the `expect_string` was changed to `r'#'`.
+    - the start and end scripts are now `"echo SCRIPT_NONO_START\n"` and `"echo SCRIPT_NONO_FIN\n"`.
+- The output in json format now includes a new key, with the IP of the router.
 
 ## [7.13.1] - 2022-03-17
 

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,7 @@
     - the `expect_string` was changed to `r'#'`.
     - the start and end scripts are now `"echo SCRIPT_NONO_START\n"` and `"echo SCRIPT_NONO_FIN\n"`.
 - The output in json format now includes a new key, with the IP of the router.
+- Data file and Plugin can now reside on a different folder other than the root of taskAutom.
 
 ## [7.13.1] - 2022-03-17
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,10 +7,11 @@
     - New parameter `readTimeOut` is used insted. In seconds, sets the amount of time `taskAutom` waits for output from router. Default to 10 seconds.
     - This change also affects the building of the inventory file, if used.
 - Upgrade of `paramiko` library to version 2.11.0
+- Upgrade of `pandas` library to version 1.4.1
 - Better detection of ssh-tunnels under the function `fncSshServer()`.
 - Final report shows times in minutes if greater than 120s.
 - In the definition of the dictionary `DICT_VENDOR`
-    - the `expect_string` was changed to `r'#'`.
+    - the `expect_string` was changed to `r'#\s$'`.
     - the start and end scripts are now `"echo SCRIPT_NONO_START\n"` and `"echo SCRIPT_NONO_FIN\n"`.
 - The output in json format now includes a new key, with the IP of the router.
 - Data file and Plugin can now reside on a different folder other than the root of taskAutom.

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Versions #
 
+## [7.14.0] - 2022-06-25
+
+- Upgrade of `netmiko` library to version 4.1.0
+    - `delayFactor` and `maxLoops` are no longer used;
+    - New parameter `readTimeOut` is used insted. In seconds, sets the amount of time `taskAutom` waits for output from router.
+    - This change also affects the building of the inventory file, if used.
+- Upgrade of `paramiko` library to version 2.11.0
+- Better detection of ssh-tunnels under the function `fncSshServer()`.
+- Final report shows times in minutes if greater than 120s.
+- In function `fncWriteToConnection()` the `expect_string` was disabled from the `send_command()` method.
+
 ## [7.13.1] - 2022-03-17
 
 - When using option `-pt show` a `json` file is created where output is stored. Each `show` command is used as a key inside the json file. This will help for output checking.

--- a/example/example.csv
+++ b/example/example.csv
@@ -1,2 +1,3 @@
+ip,name,port,intName,intAddr
 10.0.0.1,router1,1/1/1,inter1,192.168.0.1/30
 10.0.0.2,router2,1/3/5,inter7,192.168.2.1/30

--- a/example/example.py
+++ b/example/example.py
@@ -1,10 +1,10 @@
 def construir_cliLine(m, datos, lenData, mop=None):
 
-    system  = datos[0]
-    rtrName = datos[1]
-    intName = datos[2]
-    port    = datos[3]
-    ipAddr  = datos[4]
+    system  = datos.ip
+    rtrName = datos.name
+    intName = datos.intName
+    port    = datos.port
+    ipAddr  = datos.intAddr
 
     title    = ""
     cfg      = "" 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-paramiko==2.7.2
+paramiko==2.11.0
 sshtunnel==0.4.0
-netmiko==3.4.0
+netmiko==4.1.0
 scp==0.13.3
 pandas==1.2.4
 nuitka==0.6.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ paramiko==2.11.0
 sshtunnel==0.4.0
 netmiko==4.1.0
 scp==0.13.3
-pandas==1.2.4
+pandas==1.4.1
 nuitka==0.6.10
 pyyaml==5.3.1
 python-docx==0.8.10

--- a/taskAutom.py
+++ b/taskAutom.py
@@ -9,6 +9,7 @@
 # but WITHOUT ANY WARRANTY of any kind whatsoever.
 #
 
+from distutils import cmd
 import paramiko
 import sshtunnel
 from netmiko import ConnectHandler
@@ -82,7 +83,7 @@ DICT_VENDOR = dict(
 		VERSION_REGEX    = "(TiMOS-[A-Z]-\d{1,2}.\d{1,2}.R\d{1,2})",
 		HOSTNAME_REGEX   = "(A:|B:)(.+)(>|#)",
 		SHOW_REGEX       = "(\/show|show)\s.+",
-		SEND_CMD_REGEX   = r"#",
+		SEND_CMD_REGEX   = r"#\s+$",
 		MAJOR_ERROR_LIST = ["^FAILED:.+","^ERROR:.+","^Error:.+","invalid token","not allowed"],
 		MINOR_ERROR_LIST = ["^MINOR:.+"],
 		INFO_ERROR_LIST  = ["^INFO:.+"],
@@ -98,7 +99,7 @@ DICT_VENDOR = dict(
 		VERSION_REGEX    = "(TiMOS-[A-Z]-\d{1,2}.\d{1,2}.R\d{1,2})",
 		HOSTNAME_REGEX   = "(A:|B:)(.+)(>|#)",
 		SHOW_REGEX       = "(\/show|show)\s.+",
-		SEND_CMD_REGEX   = r"#",
+		SEND_CMD_REGEX   = r"#\s+$",
 		MAJOR_ERROR_LIST = ["^FAILED:.+","^ERROR:.+","^Error:.+","invalid token","not allowed"],
 		MINOR_ERROR_LIST = ["^MINOR:.+"],
 		INFO_ERROR_LIST  = ["^INFO:.+"],
@@ -854,7 +855,6 @@ class myConnection(threading.Thread):
 				try:
 					for cmd in inText:
 						rx        = conn2rtr.send_command(cmd, expect_string=expectString, cmd_verify=cmdVerify, read_timeout=readTimeOut)
-						#rx        = conn2rtr.send_command(cmd, cmd_verify=cmdVerify, read_timeout=readTimeOut)
 						outputTxt = outputTxt + '\n' + cmd + '\n' + rx
 						outputJson[cmd] = rx
 					aluLogReason = ""
@@ -1080,7 +1080,7 @@ class myConnection(threading.Thread):
 		index      = 0
 
 		systemIP   = connInfo['systemIP']
-		deviceType = connInfo['deviceType']
+		deviceType = connInfo['deviceType']	
 
 		if connInfo['useSSHTunnel'] == 'yes':
 			ip   = IP_LOCALHOST
@@ -1096,7 +1096,7 @@ class myConnection(threading.Thread):
 			index 	 = index + 1
 
 			try:
-				conn2rtr = ConnectHandler(device_type=deviceType, host=ip, port=port, username=tempUser, password=tempPass, fast_cli = False)
+				conn2rtr = ConnectHandler(device_type=deviceType, host=ip, port=port, username=tempUser, password=tempPass, fast_cli=False)
 				aluLogged    = 1
 				aluLogReason = "LoggedOk"
 				aluLogUser   = tempUser

--- a/taskAutom.py
+++ b/taskAutom.py
@@ -853,8 +853,8 @@ class myConnection(threading.Thread):
 				
 				try:
 					for cmd in inText:
-						rx        = conn2rtr.send_command(cmd, expect_string=expectString, cmd_verify=cmdVerify, read_timeout=readTimeOut)
-						#rx        = conn2rtr.send_command(cmd, cmd_verify=cmdVerify, read_timeout=readTimeOut)
+						#rx        = conn2rtr.send_command(cmd, expect_string=expectString, cmd_verify=cmdVerify, read_timeout=readTimeOut)
+						rx        = conn2rtr.send_command(cmd, cmd_verify=cmdVerify, read_timeout=readTimeOut)
 						outputTxt = outputTxt + '\n' + cmd + '\n' + rx
 						outputJson[cmd] = rx
 					aluLogReason = ""

--- a/taskAutom.py
+++ b/taskAutom.py
@@ -74,10 +74,10 @@ LOG_GLOBAL                = []
 # - Parameters per vendor
 DICT_VENDOR = dict(
 	nokia_sros=dict(
-		START_SCRIPT     = "# SCRIPT_NONO_START", # no \n in the end
+		START_SCRIPT     = "echo SCRIPT_NONO_START\n", 
 		FIRST_LINE       = "\n/environment no more\n",
 		LAST_LINE        = "\nexit all\n",
-		FIN_SCRIPT       = "# SCRIPT_NONO_FIN", # no \n in the end
+		FIN_SCRIPT       = "echo SCRIPT_NONO_FIN\n",
 		VERSION 	     = "show version", # no \n in the end
 		VERSION_REGEX    = "(TiMOS-[A-Z]-\d{1,2}.\d{1,2}.R\d{1,2})",
 		HOSTNAME_REGEX   = "(A:|B:)(.+)(>|#)",
@@ -90,10 +90,10 @@ DICT_VENDOR = dict(
 		SFTP_PORT        = 22,
 	),
 	nokia_sros_telnet=dict(
-		START_SCRIPT     = "# SCRIPT_NONO_START", # no \n in the end
+		START_SCRIPT     = "echo SCRIPT_NONO_START\n", 
 		FIRST_LINE       = "\n/environment no more\n",
 		LAST_LINE        = "\nexit all\n",
-		FIN_SCRIPT       = "# SCRIPT_NONO_FIN", # no \n in the end
+		FIN_SCRIPT       = "echo SCRIPT_NONO_FIN\n",
 		VERSION 	     = "show version", # no \n in the end
 		VERSION_REGEX    = "(TiMOS-[A-Z]-\d{1,2}.\d{1,2}.R\d{1,2})",
 		HOSTNAME_REGEX   = "(A:|B:)(.+)(>|#)",
@@ -853,8 +853,8 @@ class myConnection(threading.Thread):
 				
 				try:
 					for cmd in inText:
-						#rx        = conn2rtr.send_command(cmd, expect_string=expectString, cmd_verify=cmdVerify, read_timeout=readTimeOut)
-						rx        = conn2rtr.send_command(cmd, cmd_verify=cmdVerify, read_timeout=readTimeOut)
+						rx        = conn2rtr.send_command(cmd, expect_string=expectString, cmd_verify=cmdVerify, read_timeout=readTimeOut)
+						#rx        = conn2rtr.send_command(cmd, cmd_verify=cmdVerify, read_timeout=readTimeOut)
 						outputTxt = outputTxt + '\n' + cmd + '\n' + rx
 						outputJson[cmd] = rx
 					aluLogReason = ""
@@ -1168,6 +1168,7 @@ class myConnection(threading.Thread):
 
 		if connInfo['aluLogged'] == 1 and outRxJson != {}:
 			outRxJson['name'] = connInfo['hostname']
+			outRxJson['ip']   = connInfo['systemIP']
 			with open(aluFileOutRxJson,'w') as fj:
 				json.dump(outRxJson,fj)
 

--- a/taskAutom.py
+++ b/taskAutom.py
@@ -1116,7 +1116,7 @@ class myConnection(threading.Thread):
 		# Sending script to ALU
 		tStart 		 = time.time()
 
-		fin_script       = DICT_VENDOR[connInfo['deviceType']]['FIN_SCRIPT']
+		fin_script       = DICT_VENDOR[connInfo['deviceType']]['FIN_SCRIPT'].replace("echo ","").replace("\n","")
 		major_error_list = DICT_VENDOR[connInfo['deviceType']]['MAJOR_ERROR_LIST']
 		minor_error_list = DICT_VENDOR[connInfo['deviceType']]['MINOR_ERROR_LIST']
 		info_error_list  = DICT_VENDOR[connInfo['deviceType']]['INFO_ERROR_LIST']


### PR DESCRIPTION
- Upgrade of `netmiko` library to version 4.1.0
    - `delayFactor` and `maxLoops` are no longer used;
    - New parameter `readTimeOut` is used insted. In seconds, sets the amount of time `taskAutom` waits for output from router. Default to 10 seconds.
    - This change also affects the building of the inventory file, if used.
- Upgrade of `paramiko` library to version 2.11.0
- Upgrade of `pandas` library to version 1.4.1
- Better detection of ssh-tunnels under the function `fncSshServer()`.
- Final report shows times in minutes if greater than 120s.
- In the definition of the dictionary `DICT_VENDOR`
    - the `expect_string` was changed to `r'#\s$'`.
    - the start and end scripts are now `"echo SCRIPT_NONO_START\n"` and `"echo SCRIPT_NONO_FIN\n"`.
- The output in json format now includes a new key, with the IP of the router.
- Data file and Plugin can now reside on a different folder other than the root of taskAutom.